### PR TITLE
code: split key-value pairs by first occurrence of delimiter in FRAME.py

### DIFF
--- a/stomp_ws/frame.py
+++ b/stomp_ws/frame.py
@@ -40,7 +40,7 @@ class Frame:
         i = 1
         while lines[i] != '':
             # get key, value from raw header
-            (key, value) = lines[i].split(':')
+            (key, value) = lines[i].split(":", 1)
             headers[key] = value
             i += 1
 


### PR DESCRIPTION

This pull request addresses an issue where parsing key-value pairs from a STOMP `CONNECTED` frame fails if a value contains multiple colons (`:`). 

#### Background

In the current implementation, the parsing logic splits each line of the `CONNECTED` frame using `:` to extract key-value pairs. While this works for most cases, it fails when the value itself contains additional colons. For example:

**Current Logic:**

Input:
```
CONNECTED
server:ActiveMQ/6.1.4
heart-beat:10000,10000
session:ID:SATHVIK-PC-23512-5483528465960-1:21
version:1.1
user-name:user
```

Error:
```
ERROR - error from callback <bound method Client._on_message of <stomp_ws.client.Client object at 0x7f910537ce50>>: too many values to unpack (expected 2)
```

The specific issue occurs in the line:
```
session:ID:SATHVIK-PC-23512-5483528465960-1:21
```

The existing logic splits the string into more than two parts due to the multiple colons, leading to a "too many values to unpack" error.

#### Proposed Changes

The updated logic ensures that the string is split only at the **first occurrence** of `:`. This change correctly parses the key-value pair, regardless of additional colons in the value.

**Example After Changes:**

Input:
```
session:ID:SATHVIK-PC-23512-5483528465960-1:21
```

Parsed Result:
```
key = session
value = ID:SATHVIK-PC-23512-5483528465960-1:21
```

#### Impact

With this fix, the parser now works correctly for all cases, including those with values containing multiple colons. The error:
```
ERROR - error from callback <bound method Client._on_message of <stomp_ws.client.Client object at 0x7f910537ce50>>: too many values to unpack (expected 2)
```
is resolved.

#### Closing Issues

This pull request resolves **https://github.com/GlassyWing/stomp_ws_py/issues/7**.

#### Testing

The updated logic has been tested with various `CONNECTED` frames, including edge cases where values contain multiple colons. The changes ensure robust parsing without breaking existing functionality.